### PR TITLE
Fix verify credentials

### DIFF
--- a/lib/executables/exec.js
+++ b/lib/executables/exec.js
@@ -27,22 +27,43 @@ exports.runExec = async function runExec(componentPath, functionName, fixtureKey
   print.info('\nResult: \n');
 
   if (funcName === 'verify') {
-    let response;
-    try {
-      response = await func.call(emitter, cfg, (e, result) => {
-        if (e) throw e;
-        else if (result) return result;
-      }, snapshot);
-      if (!Object.keys(response).includes('verified')) response = { verified: response };
-      print.data(utils.formatObject(response));
-    } catch (e) {
-      print.error(utils.formatObject({
-        verified: false,
-        reason: e.context || e.message,
-      }));
-    } finally {
-      utils.destroyProcess();
+    // eslint-disable-next-line no-inner-declarations
+    function doVerification(verify) {
+      // eslint-disable-next-line no-async-promise-executor
+      return new Promise(async (resolve, reject) => {
+        function legacyCallback(e, result) {
+          if (e) {
+            reject(e);
+          }
+          resolve(result);
+        }
+        try {
+          const result = await verify.call(emitter, cfg, legacyCallback);
+          if (result) {
+            resolve(result);
+          }
+        } catch (e) {
+          print.error(e);
+        }
+      });
     }
+
+
+    doVerification(func)
+      .then((result) => {
+        if (!Object.keys(result).includes('verified')) {
+          print.data(utils.formatObject({ verified: true }));
+        } else {
+          print.data(utils.formatObject(result));
+        }
+        return result;
+      })
+      .catch((e) => {
+        print.error(utils.formatObject({
+          verified: false,
+          reason: e.context || e.message,
+        }));
+      });
   } else if (funcName === 'process') {
     await runFunction(func, emitter, [msg, cfg, snapshot]);
   } else {


### PR DESCRIPTION
While not as robust as the Sailor `verifyCredentials`, this fix makes them work more similarily, though this should work with most async functions. Like sailor, it may not be perfectly compatible with every mechanism to write a `verify` function, but should work for almost all of them, and all of the modern implementations. 